### PR TITLE
feat: DX options for shaping the MCP tool surface

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -263,8 +263,8 @@ function toDescriptor(
 }
 
 /** Composes a tool description from the field's SDL: docstring, signature, args, and result. */
-// biome-ignore lint/suspicious/noExplicitAny: a root field's source/context types are irrelevant here
 function buildDescription(
+  // biome-ignore lint/suspicious/noExplicitAny: a root field's source/context types are irrelevant here
   field: GraphQLField<any, any>,
   kind: OperationKind,
   selection: string,


### PR DESCRIPTION
Six DX additions for shaping how a GraphQL schema gets projected into MCP tools. Before this, the only lever was a `filter` callback: descriptions came from SDL and nothing else, there was no way to add MCP-only fields, and custom scalars reached agents as opaque values.

## What's in it

**`include` / `exclude` rule lists** — graphql-shield-style patterns (`'todos'`, `'Query.*'`, `'delete*'`, `'Mutation.resetDb'`) instead of hand-writing a filter. Patterns match GraphQL field names, never remapped tool names, and only drop fields. An omitted `include` keeps everything; a present-but-empty array matches nothing, so a computed allow-list fails closed rather than publishing the whole API.

**`extensions.mcp` metadata** — per-field agent guidance set in schema code (`hidden`, `name`, `title`, `description`, `appendDescription`, `annotations`, `selectionDepth`), read at tool-build time.

**`decorate` callback** — the last word on every generated descriptor, for cross-cutting rewrites ("prefix every mutation description with a confirmation hint"). Precedence is SDL defaults < `extensions.mcp` < `decorate`.

**`extend`** — MCP-only SDL + resolvers merged via `@graphql-tools/schema`'s `mergeSchemas` before tool generation, for fields that shouldn't exist on the public API (usage guides, aggregate helpers). The extended schema feeds both `buildTools` and the default local executor.

**`scalars`** — a `Record<string, ZodTypeAny>` keyed by scalar name, or a resolver returning `undefined` to fall through. Consulted *before* the built-ins so `ID`/`String` can be retyped, and it supplies only the base type — nullability, lists, and input-object nesting are applied around whatever comes back. The record shape is deliberately structural, so a generated map (`defaultScalarMap` from `@vantreeseba/graphql-zod`) spreads straight in with no adapter and no new dependency.

**`metaTools`** — opt-in `graphql_introspect` / `search` / `validate` / `execute`, for schemas too large to project one tool per field. Composes with the generated tools or replaces them entirely.

**`extend.typesOnly` / `stripRootTypes`** — drops the base `Query`/`Mutation`/`Subscription` types and keeps everything else, so callers can design a tool-specific operation surface on top of the real schema's types.

## The two decisions worth reviewing

**Meta tools are opt-in because `execute` widens what an agent can reach.** A generated tool can only run its own pre-built operation; `execute` runs a document the agent wrote. Without a check that's a way straight around `include`/`exclude`. So `buildMetaTools` defaults its rules to the server's own, and `execute` matches *every* root field of the incoming document against them — expanding fragment spreads and inline fragments first, so a root-level spread can't smuggle a denied field past the check. Mutations are refused unless `includeMutations` allows them, subscriptions are always refused, and results are clamped at `maxChars` (default 50k). The rule-enforcement paths carry the heaviest test coverage in the PR for that reason.

**`typesOnly` needed a local helper.** The Guild's `filterSchema` only filters root *fields*, which leaves an empty — and therefore invalid — root type, so it can't do this. `stripRootTypes` rebuilds the schema without the root types, carrying the `GraphQLScalarType` instances over rather than re-creating them, so custom scalar serializers survive the merge (there's a test pinning that). Since no base root type is left to extend, the extension `typeDefs` must declare `type Query { … }` rather than `extend type Query`; `extendSchemaForMcp` throws with that guidance if the merged schema ends up with no query type.

## Breaking-ish change

`GraphqlRequest.operationName` is now **optional**. Generated tools still always set it. It changed because a hand-written document passed to the `execute` meta tool may define a single anonymous operation, where omitting the name means "run the document's only operation" — matching graphql-js's own rule. Both executors already tolerate it (graphql-js `execute` picks the single operation; `JSON.stringify` drops `undefined` for the HTTP executor). Only a caller who *implements* `GraphqlExecutor` and destructures `operationName` as a required string is affected.

Also fixed along the way: a renamed tool (`toolName`, `extensions.mcp.name`, or `decorate`) sent `operationName: descriptor.name` while the document was named after the field — so every renamed tool failed with "Unknown operation named …". `ToolDescriptor` now carries `operationName` explicitly.

## Verification

`npm test` 131/131 (59 new) · `typecheck` + `typecheck:tests` + `check` + `build` clean · coverage 98.7% lines / 95.9% branches, `meta.ts` at 100% lines / 97.4% branches.

Docs updated: README gained sections for custom scalars, meta tools, and the types-only surface; AGENTS.md gained `meta.ts` in the structure map plus architecture notes on the rule-enforcement invariant and the type-only `CustomTool` import that keeps `meta.ts` ↔ `server.ts` acyclic; TODO.md drops the now-delivered scalar-map item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
